### PR TITLE
AR-99: Allow service to create root span if cofigured

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,4 +11,5 @@ type Config struct {
 	Headers        string  `json:"headers" mapstructure:"headers"`
 	BatchTimeout   int     `json:"batchTimeout" mapstructure:"batchTimeout"`
 	SamplingRate   float64 `json:"samplingRate" mapstructure:"samplingRate"`
+	AlwaysSample   bool    `json:"alwaysSample" mapstructure:"alwaysSample"`
 }

--- a/middleware.go
+++ b/middleware.go
@@ -39,16 +39,16 @@ func GRPCUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	) (interface{}, error) {
 		// Extract trace context from incoming metadata
 		md, _ := metadata.FromIncomingContext(ctx)
-		extractedCtx := otel.GetTextMapPropagator().Extract(ctx, metadataTextMapCarrier(md))
+		spanCtx, shouldTrace := getSpanContext(ctx, metadataTextMapCarrier(md))
 
 		// Only create spans if there's a valid parent trace context
-		if !hasValidTraceContext(extractedCtx) {
+		if !shouldTrace {
 			return handler(ctx, req)
 		}
 
 		// Create span only when parent trace exists
 		ctx, span := otel.Tracer("grpc-server").Start(
-			extractedCtx,
+			spanCtx,
 			info.FullMethod,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
@@ -98,16 +98,16 @@ func GRPCStreamServerInterceptor() grpc.StreamServerInterceptor {
 
 		// Extract trace context from incoming metadata
 		md, _ := metadata.FromIncomingContext(ctx)
-		extractedCtx := otel.GetTextMapPropagator().Extract(ctx, metadataTextMapCarrier(md))
+		spanCtx, shouldTrace := getSpanContext(ctx, metadataTextMapCarrier(md))
 
 		// Only create spans if there's a valid parent trace context
-		if !hasValidTraceContext(extractedCtx) {
+		if !shouldTrace {
 			return handler(srv, stream)
 		}
 
 		// Create span only when parent trace exists
 		ctx, span := otel.Tracer("grpc-server").Start(
-			extractedCtx,
+			spanCtx,
 			info.FullMethod,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
@@ -155,17 +155,16 @@ func GRPCStreamServerInterceptor() grpc.StreamServerInterceptor {
 func HTTPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Extract trace context from headers
-		extractedCtx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		spanCtx, shouldTrace := getSpanContext(r.Context(), propagation.HeaderCarrier(r.Header))
 
-		// Only create spans if there's a valid parent trace context
-		if !hasValidTraceContext(extractedCtx) {
+		if !shouldTrace {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		// Create span only when parent trace exists
+		// Create span (either continuing parent or as root)
 		ctx, span := otel.Tracer("http-server").Start(
-			extractedCtx,
+			spanCtx,
 			fmt.Sprintf("%s %s", r.Method, r.URL.Path),
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
@@ -372,6 +371,26 @@ func InjectHTTPHeaders(req *http.Request) {
 
 	// Inject trace context into HTTP headers
 	otel.GetTextMapPropagator().Inject(req.Context(), propagation.HeaderCarrier(req.Header))
+}
+
+func getSpanContext(ctx context.Context, carrier propagation.TextMapCarrier) (context.Context, bool) {
+	extractedCtx := otel.GetTextMapPropagator().Extract(ctx, carrier)
+
+	// Determine if we should create a span:
+	// 1. If there's a valid parent trace context - continue the trace
+	// 2. If AlwaysSample is true - create a root span even without parent
+	shouldTrace := hasValidTraceContext(extractedCtx) || IsAlwaysSampleEnabled()
+
+	if !shouldTrace {
+		return ctx, false
+	}
+
+	// Use extractedCtx if parent exists, otherwise use original context for root span
+	spanCtx := extractedCtx
+	if !hasValidTraceContext(extractedCtx) && IsAlwaysSampleEnabled() {
+		spanCtx = ctx // This will create a root span
+	}
+	return spanCtx, true
 }
 
 // Helper for client stream

--- a/provider.go
+++ b/provider.go
@@ -16,6 +16,22 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
 
+// globalConfig stores the configuration globally so middleware can access it
+var globalConfig *Config
+
+// GetGlobalConfig returns the globally stored configuration
+func GetGlobalConfig() *Config {
+	return globalConfig
+}
+
+// IsAlwaysSampleEnabled checks if AlwaysSample is enabled in the global config
+func IsAlwaysSampleEnabled() bool {
+	if globalConfig == nil {
+		return false
+	}
+	return globalConfig.AlwaysSample
+}
+
 type Provider struct {
 	cfg           *Config
 	traceProvider *sdktrace.TracerProvider
@@ -23,6 +39,9 @@ type Provider struct {
 
 // New initializes OpenTelemetry tracing
 func New(ctx context.Context, cfg *Config) (*Provider, error) {
+	// Store config globally so middleware can access it
+	globalConfig = cfg
+	
 	// Skip if disabled
 	if !cfg.Enabled {
 		return &Provider{}, nil


### PR DESCRIPTION
**Description**:
This PR introduces an `AlwaysSample` configuration option to the OpenTelemetry setup, enabling forced creation of root spans for gRPC and HTTP requests, even when no parent trace context is present. The change ensures that tracing can be initiated without requiring an incoming trace context, improving observability for standalone requests when enabled.

**Changes**:
- Added `AlwaysSample` boolean field to the `Config` struct in `config.go`.
- Introduced `getSpanContext` function in `middleware.go` to handle trace context extraction and determine whether to create spans based on `AlwaysSample` or valid parent trace context.
- Updated gRPC and HTTP middleware to use `getSpanContext`, creating root spans when `AlwaysSample` is enabled and no parent trace exists.
- Added `globalConfig` and helper functions in `provider.go` to store and access the configuration globally, enabling middleware to check `AlwaysSample`.
- Ensured backward compatibility by defaulting to existing behavior when `AlwaysSample` is false or unset.

**Impact**:
- Allows forced tracing for debugging or monitoring standalone requests.
- No changes to existing behavior unless `AlwaysSample` is explicitly enabled.
- Improves flexibility in tracing configuration without affecting performance when disabled.

**Testing**:
- Verified that spans are created only with valid parent trace context when `AlwaysSample` is false.
- Confirmed root spans are created for requests without parent trace context when `AlwaysSample` is true.
- Tested gRPC unary, and HTTP middleware for correct span creation and propagation (didn't test streaming).

**Related Issues**:
- Addresses requirement for configurable root span creation in tracing setup.
